### PR TITLE
WEBUI-655: add sample workflow with dispatch event

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,0 +1,18 @@
+# Sample workflow for testing the trigger-workflow action, 
+# not intended to be triggered manually.
+name: Simple workflow with dispatch trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      string_parameter:
+        description: 'Simple string parameter'
+        default: 'String parameter'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo string parameter
+        run: echo ${{ github.event.inputs.string_parameter }}


### PR DESCRIPTION
This is a sample workflow that we will use for testing the trigger workflow action. 

I am opening a PR just with this wf, cecause we cannot trigger the `workflow_dispatch` event in workflows that are not in the reference branch.